### PR TITLE
Fix - Removes deprecated `new Buffer` invocation

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function() {
             contents = contents.replace(sub, replaceString);
         }
 
-        file.contents = new Buffer(contents);
+        file.contents = Buffer.from(contents);
         cb(null, file);
     };
     return through.obj(transform);


### PR DESCRIPTION
Uses the more stable `Buffer.from` instead.

This changes the node version required for this, looks to be to at least
5.10.0, which obviously hasn't been supported for a while, so setting a minimum of 6 (probably 8) should be fine for me to put on this repo.

See https://nodejs.org/docs/latest-v12.x/api/buffer.html#buffer_new_buffer_array