### PR TITLE
Chore - Renames published NPM Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@romellem/gulp-sass-bulk-import",
+  "name": "gulp-sass-bulk-importer",
   "version": "2.0.0",
   "description": "import directories in your SCSS",
   "main": "index.js",


### PR DESCRIPTION
Renaming from `gulp-sass-bulk-import` to `gulp-sass-bulk-importer` (adds `er` to the end).

Maybe will think about moving this to @designory, and publish under that
organization, since I'm not a fan of having this under a totally different name,
I feel like that hurts discoverability.